### PR TITLE
Handle tags without entries

### DIFF
--- a/lib/exif_parser/image_file_directory.ex
+++ b/lib/exif_parser/image_file_directory.ex
@@ -99,6 +99,8 @@ defmodule ExifParser.ImageFileDirectory do
     ]
   end
 
+  defp parse_tags(%__MODULE__{num_entries: 0}, _endian, _start, _tag_type), do: nil
+
   defp parse_tags(
          %__MODULE__{offset: ifd_offset, num_entries: num_entries},
          endian,


### PR DESCRIPTION
Thanks for a useful library.

I recently came across an issue in which the library crashed if any of the exif tags were empty (`num_entries = 0`), this is often the case for the GPS tag when taking pictures with certain android phones. 
